### PR TITLE
Add Command Base

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/src/index.ts",
+            "args": ["start"],
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "eslint.run": "onSave",
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558 
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "start",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sr-bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -67,7 +67,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -130,7 +129,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -138,8 +136,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -156,26 +153,22 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -246,7 +239,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       },
@@ -254,22 +246,19 @@
         "tweetnacl": {
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         }
       }
     },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
-      "dev": true
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boxen": {
       "version": "1.3.0",
@@ -340,8 +329,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -364,7 +352,6 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
-      "dev": true,
       "requires": {
         "css-select": "~1.2.0",
         "dom-serializer": "~0.1.0",
@@ -441,7 +428,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -449,8 +435,7 @@
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-      "dev": true
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -513,8 +498,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -548,7 +532,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
       "requires": {
         "boolbase": "~1.0.0",
         "css-what": "2.1",
@@ -559,8 +542,7 @@
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-      "dev": true
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -575,7 +557,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -628,8 +609,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "3.5.0",
@@ -641,7 +621,6 @@
       "version": "11.4.2",
       "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.4.2.tgz",
       "integrity": "sha512-MDwpu0lMFTjqomijDl1Ed9miMQe6kB4ifKdP28QZllmLv/HVOJXhatRgjS8urp/wBlOfx+qAYSXcdI5cKGYsfg==",
-      "dev": true,
       "requires": {
         "long": "^4.0.0",
         "prism-media": "^0.0.3",
@@ -663,7 +642,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
@@ -672,14 +650,12 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -688,7 +664,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -713,7 +688,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -728,8 +702,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -898,8 +871,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
       "version": "3.0.3",
@@ -915,20 +887,17 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -983,14 +952,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1019,7 +986,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1100,14 +1066,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -1146,7 +1110,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -1160,7 +1123,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1223,8 +1185,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -1355,8 +1316,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1373,8 +1333,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1395,8 +1354,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -1407,14 +1365,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1425,14 +1381,12 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -1492,80 +1446,67 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
-      "dev": true
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.bind": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
-      "dev": true
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
     },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.filter": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
-      "dev": true
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.foreach": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
-      "dev": true
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-      "dev": true
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-      "dev": true
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.reduce": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
-      "dev": true
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
     },
     "lodash.reject": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
-      "dev": true
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
     },
     "lodash.some": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
-      "dev": true
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.unescape": {
       "version": "4.0.1",
@@ -1576,8 +1517,7 @@
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -1648,14 +1588,12 @@
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
-      "dev": true
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
-      "dev": true,
       "requires": {
         "mime-db": "~1.38.0"
       }
@@ -1749,7 +1687,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
       }
@@ -1757,8 +1694,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "once": {
       "version": "1.4.0",
@@ -1808,7 +1744,6 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/overwatch-api/-/overwatch-api-0.7.5.tgz",
       "integrity": "sha512-/02mtDXEOM6p+DY1r5wj5tzkZjG2EfcjEKBlJjEPi//ix6g6AjxrxyJoItcIuP7ZKqeIyyEG9qtsYjj7vUCS4A==",
-      "dev": true,
       "requires": {
         "async": "^2.6.1",
         "cheerio": "^0.22.0",
@@ -1821,7 +1756,6 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-          "dev": true,
           "requires": {
             "lodash": "^4.17.11"
           }
@@ -1939,8 +1873,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "4.0.1",
@@ -1996,8 +1929,7 @@
     "prism-media": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.3.tgz",
-      "integrity": "sha512-c9KkNifSMU/iXT8FFTaBwBMr+rdVcN+H/uNv1o+CuFeTThNZNTOrQ+RgXA1yL/DeLk098duAeRPP3QNPNbhxYQ==",
-      "dev": true
+      "integrity": "sha512-c9KkNifSMU/iXT8FFTaBwBMr+rdVcN+H/uNv1o+CuFeTThNZNTOrQ+RgXA1yL/DeLk098duAeRPP3QNPNbhxYQ=="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -2020,20 +1952,17 @@
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-      "dev": true
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -2086,7 +2015,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
       "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2132,7 +2060,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2160,7 +2087,6 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
       "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
-      "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
         "request-promise-core": "1.1.2",
@@ -2172,7 +2098,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -2232,14 +2157,12 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.5.0",
@@ -2291,8 +2214,7 @@
     "snekfetch": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
-      "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw==",
-      "dev": true
+      "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
     },
     "spawn-sync": {
       "version": "1.0.15",
@@ -2346,7 +2268,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -2362,16 +2283,14 @@
         "tweetnacl": {
           "version": "0.14.5",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         }
       }
     },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "2.1.1",
@@ -2387,7 +2306,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -2437,8 +2355,7 @@
     "svg-builder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-builder/-/svg-builder-1.0.0.tgz",
-      "integrity": "sha512-Alb20G9MRQLXnc8YhVfimUJdHqQB2KK1/J/0pAlAoRdtD+V8ryoZCNtkDBAGxQuNyd+lX9qb0RKpZ3kso45K+w==",
-      "dev": true
+      "integrity": "sha512-Alb20G9MRQLXnc8YhVfimUJdHqQB2KK1/J/0pAlAoRdtD+V8ryoZCNtkDBAGxQuNyd+lX9qb0RKpZ3kso45K+w=="
     },
     "table": {
       "version": "5.2.3",
@@ -2520,7 +2437,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -2529,8 +2445,7 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
@@ -2580,7 +2495,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2588,8 +2502,7 @@
     "tweetnacl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A==",
-      "dev": true
+      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -2649,7 +2562,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -2666,14 +2578,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -2689,7 +2599,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -2750,7 +2659,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0",
         "safe-buffer": "~5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -424,6 +424,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Derek Sims (SCRAWCHIMARI#1144)",
   "license": "ISC",
   "dependencies": {
+    "colors": "^1.3.3",
     "commander": "^2.19.0",
     "discord.js": "^11.4.2",
     "overwatch-api": "^0.7.5"

--- a/res/overwatch.example.json
+++ b/res/overwatch.example.json
@@ -3,6 +3,7 @@
     "servers": [
         {
             "id": "DISCORD_SERVER_ID",
+            "admins": ["USERNAME", "USERNAME"],
             "platform": "PLATFORM",
             "region": "REGION",
             "players": [

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -19,7 +19,10 @@ enum COMMAND {
  * Enum of updatable commands
  */
 enum UPDATABLE_COMMAND {
-    TEAM = 'TEAM'
+    TEAM = 'TEAM',
+    REGION = 'REGION',
+    PLATFORM = 'PLATFORM'
+
 }
 
 /**
@@ -168,10 +171,19 @@ export class SrBot {
                 switch (params[0].toUpperCase()) {
                     case UPDATABLE_COMMAND.TEAM: {
                         // !sr set team ####
-
                         const teamName = settableParams.join(' ');
                         this.statsGenerator.updateServerProperty(serverId, 'teamName', teamName);
                         this.sendToChannel(message.channel, `Team name updated: ${teamName}`);
+                        break;
+                    }
+                    case UPDATABLE_COMMAND.REGION: {
+                        // !sr set region ####
+                        this.statsGenerator.updateServerProperty(serverId, 'region', settableParams[0].toLowerCase() as OverwatchAPI.REGION);
+                        break;
+                    }
+                    case UPDATABLE_COMMAND.PLATFORM: {
+                        // !sr set platform ####
+                        this.statsGenerator.updateServerProperty(serverId, 'platform', settableParams[0].toLowerCase() as OverwatchAPI.PLATFORM);
                         break;
                     }
                     default:

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -63,6 +63,9 @@ export class SrBot {
 
         client.on('disconnect', (e) => log('CLIENT', 'Disconnected!', 'WARN'));
         client.on('error', (e) => log('CLIENT', JSON.stringify(e), 'ERROR'));
+        client.on('reconnecting', ()=> log('CLIENT', 'Connecting...', 'ERROR'));
+        client.on('resume', ()=> log('CLIENT', 'Connected', 'SUCCESS'));
+
         return client;
     }
 

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -178,12 +178,26 @@ export class SrBot {
                     }
                     case UPDATABLE_COMMAND.REGION: {
                         // !sr set region ####
-                        this.statsGenerator.updateServerProperty(serverId, 'region', settableParams[0].toLowerCase() as OverwatchAPI.REGION);
+                        const validRegions: OverwatchAPI.REGION[] = ['cn', 'eu', 'global', 'kr', 'us'];
+                        const region = settableParams[0].toLowerCase() as OverwatchAPI.REGION;
+                        if (!validRegions.includes(region)) {
+                            this.sendToChannel(message.channel, `Invalid region: ${region}.  Use ${validRegions.join('|')}`);
+                            return;
+                        }
+                        this.statsGenerator.updateServerProperty(serverId, 'region', region);
+                        this.sendToChannel(message.channel, `Region updated: ${region}`);
                         break;
                     }
                     case UPDATABLE_COMMAND.PLATFORM: {
                         // !sr set platform ####
-                        this.statsGenerator.updateServerProperty(serverId, 'platform', settableParams[0].toLowerCase() as OverwatchAPI.PLATFORM);
+                        const validPlatforms: OverwatchAPI.PLATFORM[] = ['pc', 'psn', 'xbl'];
+                        const platform = settableParams[0].toLowerCase() as OverwatchAPI.PLATFORM;
+                        if (!validPlatforms.includes(platform)) {
+                            this.sendToChannel(message.channel, `Invalid platform: ${platform}. Use ${validPlatforms.join('|')}`);
+                            return;
+                        }
+                        this.statsGenerator.updateServerProperty(serverId, 'platform', platform);
+                        this.sendToChannel(message.channel, `Platform updated: ${platform}`);
                         break;
                     }
                     default:

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -35,19 +35,21 @@ export class SrBot {
      * @param config Loaded dicord config file data
      */
     private initializeClient(config: DiscordConfig) {
-        log('CLIENT', 'Initializing Discord Client');
+        log('CLIENT', 'Initializing Discord Client', 'INFO');
         const client = new Discord.Client();
 
         client.login(config.token)
             .then(() => {
                 client.on('message', message => this.onClientMessageHandler(message));
-                log('CLIENT', 'Discord Client Successfully Initialized');
+                log('CLIENT', 'Discord Client Successfully Initialized', 'SUCCESS');
             })
             .catch(err => {
-                log('CLIENT ERROR', 'Error on client login');
+                log('CLIENT ERROR', err, 'ERROR');
                 throw new Error(err);
             });
 
+        client.on('disconnect', (e) => log('CLIENT', 'Disconnected!', 'WARN'));
+        client.on('error', (e) => log('CLIENT ERROR', e, 'ERROR'));
         return client;
     }
 
@@ -65,10 +67,10 @@ export class SrBot {
 
     /**
      * Processes a Discord message
-     * @param {*} message
+     * @param {Discord.Message} message
      */
     private processDefaultCommand(message: Discord.Message): void {
-        log('CLIENT', `New request from ${message.author.username}`);
+        log('CLIENT', `New request from ${message.author.username}`, 'INFO');
         const serverId = message.member.guild.id;
         const requestedServer = this.statsGenerator.getServer(serverId);
 
@@ -102,7 +104,7 @@ export class SrBot {
             embed.addField('Team Stats', teamStatsMessage);
 
             // Send message to discord
-            log('CLIENT', `Sent embed to chat: ${JSON.stringify(embed)}`);
+            log('CLIENT', `Sent embed to chat: ${JSON.stringify(embed)}`, 'INFO');
             message.channel.send({embed});
         }
     }

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -148,7 +148,7 @@ export class SrBot {
             return;
         }
 
-        // If just !sr
+        // If just !sr request
         if (!command) {
             this.sendToChannel(message.channel, this.createEmbedMessage(message));
             return;
@@ -156,15 +156,19 @@ export class SrBot {
 
         // Non admin user attempted a set command
         if (command.toUpperCase() === COMMAND.SET && !this.isServerAdmin(serverId, message.author.username)) {
-            log('CLIENT', `${message.author.username} attempted set command:  Not admin!`, 'WARN');
+            log('CLIENT', `Non-admin user ${message.author.username} attempted set command`, 'WARN');
             return;
         }
 
         switch (command.toUpperCase()) {
             case COMMAND.SET: {
+                // !sr set ####
+
                 const settableParams = params.slice(1);
                 switch (params[0].toUpperCase()) {
                     case UPDATABLE_COMMAND.TEAM: {
+                        // !sr set team ####
+
                         const teamName = settableParams.join(' ');
                         this.statsGenerator.updateServerProperty(serverId, 'teamName', teamName);
                         this.sendToChannel(message.channel, `Team name updated: ${teamName}`);
@@ -177,6 +181,8 @@ export class SrBot {
                 break;
             }
             case COMMAND.TEAM: {
+                // !sr team
+
                 this.sendToChannel(message.channel, `Team name: ${server && server.teamName || 'NOT SET'}`);
                 break;
             }
@@ -188,7 +194,7 @@ export class SrBot {
 
     /**
      * Checks if a user is an admin.
-     * @param user Username
+     * @param user Username to check
      */
     private isServerAdmin(serverId: string, user: string): boolean {
         const server = this.statsGenerator.getServer(serverId);

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -1,10 +1,18 @@
 import * as Discord from 'discord.js';
 import {getRankEmoji} from './utils/getRankEmoji';
-import {DiscordConfig, ConfigurationLoc} from './types';
+import {DiscordConfig, ConfigurationLoc, Server} from './types';
 import {getJsonFile} from './utils/getJsonFile';
 import {StatsGenerator} from './StatsGenerator';
 import {log} from './utils/logger';
-import {calculateAverageSR} from './calculateAverageSr';
+import {calculateAverageSR} from './utils/calculateAverageSr';
+
+/**
+ * Enum of available commands
+ */
+enum COMMAND {
+    BASE = '!SR',
+    TEAM = 'TEAM'
+}
 
 /**
  * Defines the Hex color used in the Discord embed message
@@ -48,11 +56,11 @@ export class SrBot {
      * @param message The message received
      */
     private onClientMessageHandler(message: Discord.Message): void {
-        const isUserBot = message.author.bot;
-
-        if (!isUserBot && message.content.toLowerCase().startsWith('!sr')) {
-            this.processTextChat(message);
+        if (message.author.bot || !message.content.toUpperCase().startsWith(COMMAND.BASE)) {
+            return;
         }
+
+        this.commandHandler(message);
     }
 
     /**
@@ -60,44 +68,73 @@ export class SrBot {
      * @param {*} message
      */
     private processTextChat(message: Discord.Message): void {
-        if (message.content.toLowerCase() === '!sr') {
-            log('CLIENT', `New request from ${message.author.username}`);
-            const serverId = message.member.guild.id;
-            const requestedServer = this.statsGenerator.getLastResult().servers.find(server => serverId === server.id);
+        log('CLIENT', `New request from ${message.author.username}`);
+        const serverId = message.member.guild.id;
+        const requestedServer = this.statsGenerator.getServer(serverId);
 
-            if (!requestedServer) {
-                message.channel.send('Sorry, this server has no players associated.');
-                return;
-            } else {
-                const players = requestedServer.players;
+        if (!requestedServer) {
+            message.channel.send('Sorry, this server has no players associated.');
+            return;
+        } else {
+            const players = requestedServer.players;
 
-                // Embed Construction
-                const embed = new Discord.RichEmbed()
-                    .setTitle(`Leaderboard: ${requestedServer.teamName}`)
-                    .setColor(HEX_EMBED_COLOR)
-                    .setFooter(`Last updated: ${new Date(this.statsGenerator.getLastResult().timestamp).toUTCString()}`)
-                    .setAuthor('SR Bot', undefined, 'https://github.com/Derekholio/sr-bot');
+            // Embed Construction
+            const embed = new Discord.RichEmbed()
+                .setTitle(`Leaderboard: ${requestedServer.teamName}`)
+                .setColor(HEX_EMBED_COLOR)
+                .setFooter(`Last updated: ${new Date(this.statsGenerator.getLastResult().timestamp).toUTCString()}`)
+                .setAuthor('SR Bot', undefined, 'https://github.com/Derekholio/sr-bot');
 
-                players.forEach((player) => {
-                    embed.addField(player.player, `${player.SR}${player.private ? ' [PRIVATE]' : ''} ${getRankEmoji(player.SR)}`);
-                });
+            players.forEach((player) => {
+                embed.addField(player.player, `${player.SR}${player.private ? ' [PRIVATE]' : ''} ${getRankEmoji(player.SR)}`);
+            });
 
-                // Team Stats Construction
-                const average = calculateAverageSR(players);
-                let teamStatsMessage = `Average SR: ${average}`;
+            // Team Stats Construction
+            const average = calculateAverageSR(players);
+            let teamStatsMessage = `Average SR: ${average}`;
 
-                if (requestedServer.targetSR) {
-                    const playersCount = players.length;
-                    const target = requestedServer.targetSR;
-                    const max = Math.abs((average * playersCount) - (target * (playersCount + 1)));
-                    teamStatsMessage += `\nTarget SR: ${target}\nMax add: ${max}`;
-                }
-                embed.addField('Team Stats', teamStatsMessage);
-
-                // Send message to discord
-                log('CLIENT', `Sent embed to chat: ${JSON.stringify(embed)}`);
-                message.channel.send({embed});
+            if (requestedServer.targetSR) {
+                const playersCount = players.length;
+                const target = requestedServer.targetSR;
+                const max = Math.abs((average * playersCount) - (target * (playersCount + 1)));
+                teamStatsMessage += `\nTarget SR: ${target}\nMax add: ${max}`;
             }
+            embed.addField('Team Stats', teamStatsMessage);
+
+            // Send message to discord
+            log('CLIENT', `Sent embed to chat: ${JSON.stringify(embed)}`);
+            message.channel.send({embed});
+        }
+    }
+
+    /**
+     * Handles commands sent from discord
+     * @param message Incoming discord message
+     */
+    private commandHandler(message: Discord.Message): void {
+        const serverId = message.member.guild.id;
+        const server = this.statsGenerator.getServer(serverId);
+        const [command, ...params] = [...message.content.split(' ').slice(1)];
+
+        if (!command) {
+            this.processTextChat(message);
+            return;
+        }
+
+        switch (command.toUpperCase()) {
+            case COMMAND.TEAM:
+                if (params[0]) {
+                    const teamName = params.join(' ');
+                    this.statsGenerator.updateServerProperty(serverId, 'teamName', teamName);
+                    message.channel.send(`Team name updated: ${teamName}`);
+                } else {
+                    message.channel.send(`Team name: ${server && server.teamName || 'NOT SET'}`);
+                }
+                break;
+
+            default:
+                this.processTextChat(message);
+                break;
         }
     }
 }

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -155,7 +155,8 @@ export class SrBot {
         }
 
         // Non admin user attempted a set command
-        if (command.toUpperCase() === COMMAND.SET && this.isServerAdmin(serverId, message.author.username)) {
+        if (command.toUpperCase() === COMMAND.SET && !this.isServerAdmin(serverId, message.author.username)) {
+            log('CLIENT', `${message.author.username} attempted set command:  Not admin!`, 'WARN');
             return;
         }
 

--- a/src/SrBot.ts
+++ b/src/SrBot.ts
@@ -67,7 +67,7 @@ export class SrBot {
      * Processes a Discord message
      * @param {*} message
      */
-    private processTextChat(message: Discord.Message): void {
+    private processDefaultCommand(message: Discord.Message): void {
         log('CLIENT', `New request from ${message.author.username}`);
         const serverId = message.member.guild.id;
         const requestedServer = this.statsGenerator.getServer(serverId);
@@ -117,7 +117,7 @@ export class SrBot {
         const [command, ...params] = [...message.content.split(' ').slice(1)];
 
         if (!command) {
-            this.processTextChat(message);
+            this.processDefaultCommand(message);
             return;
         }
 
@@ -133,7 +133,7 @@ export class SrBot {
                 break;
 
             default:
-                this.processTextChat(message);
+                this.processDefaultCommand(message);
                 break;
         }
     }

--- a/src/StatsGenerator.ts
+++ b/src/StatsGenerator.ts
@@ -83,6 +83,7 @@ export class StatsGenerator {
     public updateServerProperty<T extends keyof Server>(serverId: string, property: T, value: Server[T]) {
         const serverReference = this.getServer(serverId);
         if (serverReference) {
+            log('CLIENT', `Updating ${property}: ${value}`, 'INFO');
             // Straight mutation.  It's dirty but works for now.
             Object.assign(serverReference, {[property]: value});
             writeJsonFile<OverwatchConfig>(this.configPath, this.lastResult);

--- a/src/StatsGenerator.ts
+++ b/src/StatsGenerator.ts
@@ -63,6 +63,29 @@ export class StatsGenerator {
 
 
     /**
+     * Returns the Server config for a specific server id.
+     * @param id Server Id
+     */
+    public getServer(id: String): Server|undefined {
+        return this.lastResult.servers.find(server => server.id === id);
+    }
+
+    /**
+     * Updates a top level server property.  Not really intended to update Players info.
+     * @param serverId Id of server to update
+     * @param property Server property to update
+     * @param value New property value
+     */
+    public updateServerProperty<T extends keyof Server>(serverId: string, property: T, value: Server[T]) {
+        const serverReference = this.getServer(serverId);
+        if (serverReference) {
+            // Straight mutation.  It's dirty but works for now.
+            Object.assign(serverReference, {[property]: value});
+            writeJsonFile<OverwatchConfig>(this.config.path, this.lastResult);
+        }
+    }
+
+    /**
      * Gets user data from overwatch API
      * @param {string} player Player username
      */
@@ -89,7 +112,7 @@ export class StatsGenerator {
 
         const conditionalData: Partial<Player> = {};
         const player: OverwatchAPI.Profile|null = await this.getOverwatchProfileAsync(playerData.player, locale).catch(err => {
-            log('UPDATE', `${playerData.player} not found!`);
+            log('UPDATE ERROR', `${playerData.player} not found!`);
             return null;
         });
 

--- a/src/StatsGenerator.ts
+++ b/src/StatsGenerator.ts
@@ -35,13 +35,13 @@ export class StatsGenerator {
      */
     public async fetchAndWrite(): Promise<void> {
         const start = Date.now();
-        log('UPDATE', `Begin update on ${this.configPath}`);
+        log('UPDATE', `Begin update on ${this.configPath}`, 'INFO');
 
         const results = await this.fetch();
         writeJsonFile(this.configPath, results);
 
         const end = Date.now();
-        log('UPDATE', `Finished update! Took ${(end - start) / 1000}s`);
+        log('UPDATE', `Finished update! Took ${(end - start) / 1000}s`, 'SUCCESS');
     }
 
     /**
@@ -116,7 +116,7 @@ export class StatsGenerator {
 
         const conditionalData: Partial<Player> = {};
         const player: OverwatchAPI.Profile|null = await this.getOverwatchProfileAsync(playerData.player, locale).catch(err => {
-            log('UPDATE ERROR', `${playerData.player} not found!`);
+            log('UPDATE', `${playerData.player} not found!`, 'WARN');
             return null;
         });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type Player = {
 export interface Server extends Locale {
     id: string;
     players: Player[];
+    admins: string[];
     targetSR: number|null;
     teamName: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type Player = {
 export interface Server extends Locale {
     id: string;
     players: Player[];
-    targetSR: number;
+    targetSR: number|null;
     teamName: string;
 }
 

--- a/src/utils/calculateAverageSr.ts
+++ b/src/utils/calculateAverageSr.ts
@@ -1,4 +1,4 @@
-import {Player} from './types';
+import {Player} from '../types';
 
 /**
     * Returns average SR for given players

--- a/src/utils/calculateAverageSr.ts
+++ b/src/utils/calculateAverageSr.ts
@@ -1,9 +1,9 @@
 import {Player} from '../types';
 
 /**
-    * Returns average SR for given players
-    * @param {Player[]} players Players to calculate SR for
-    */
+* Returns average SR for given players
+* @param {Player[]} players Players to calculate SR for
+*/
 export function calculateAverageSR(players: Player[]) {
     const playersCount = players.length;
     const totalSR = players.reduce((accumlated, current) => accumlated + current.SR, 0);

--- a/src/utils/getJsonFile.ts
+++ b/src/utils/getJsonFile.ts
@@ -1,6 +1,10 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
+/**
+ * Returns a JSON files contents
+ * @param filePath Path to the file
+ */
 export function getJsonFile<T>(filePath: string): T {
     const pathResolved = path.resolve(filePath);
     try {

--- a/src/utils/getRankEmoji.ts
+++ b/src/utils/getRankEmoji.ts
@@ -1,3 +1,7 @@
+/**
+ * Returns an image which corresponds to the provider SR
+ * @param sr Player SR
+ */
 export function getRankEmoji(sr: number) {
     if (between(sr, 0, 1499)) {
         return '<:ow_bronze:561738884409458701>';
@@ -13,6 +17,8 @@ export function getRankEmoji(sr: number) {
         return '<:ow_masters:561739221711192065>';
     } else if (between(sr, 4000, 5000)) {
         return '<:ow_grand_masters:561751122952323083>';
+    } else if (between(sr, 5001, Number.MAX_SAFE_INTEGER)) {
+        return ':poop:';
     } else {
         return null;
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,9 +1,9 @@
-export enum LogLevel {
-    'NORMAL',
-    'INFO',
-    'WARN',
-    'ERROR'
-}
+import 'colors';
+
+/**
+ * Different severity of logging.  Synonymous to console.log/info/war/error
+ */
+type LogLevel = 'NORMAL'|'INFO'|'WARN'|'ERROR'|'SUCCESS';
 
 /**
  * Logs a formatted message to the console
@@ -12,21 +12,25 @@ export enum LogLevel {
  * @param timestamp Log time with message
  * @param level Log Level (log, info, warn, error)
  */
-export function log(prefix: string, message: string, level?: LogLevel): void {
-    const out = `[${new Date().toLocaleTimeString()}] [${prefix}] ${message}`;
-
+export function log(prefix: string, message: any, level: LogLevel = 'NORMAL'): void {
+    let prefixColored = prefix;
     switch (level) {
-        case LogLevel.INFO:
-            console.info(out);
+        case 'SUCCESS':
+            prefixColored = prefix.green;
             break;
-        case LogLevel.WARN:
-            console.warn(out);
+        case 'INFO':
+            prefixColored = prefix.blue;
             break;
-        case LogLevel.ERROR:
-            console.error(out);
+        case 'WARN':
+            prefixColored = prefix.yellow;
+            break;
+        case 'ERROR':
+            prefixColored = prefix.red;
             break;
         default:
-            console.log(out);
+            prefixColored = prefix;
             break;
     }
+
+    console.log(`[${new Date().toLocaleTimeString()}] [${prefixColored}] ${message}`);
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -9,7 +9,6 @@ type LogLevel = 'NORMAL'|'INFO'|'WARN'|'ERROR'|'SUCCESS';
  * Logs a formatted message to the console
  * @param prefix Log Prefix [Prefix]
  * @param message Log Message
- * @param timestamp Log time with message
  * @param level Log Level (log, info, warn, error)
  */
 export function log(prefix: string, message: any, level: LogLevel = 'NORMAL'): void {

--- a/src/utils/writeJsonFile.ts
+++ b/src/utils/writeJsonFile.ts
@@ -1,6 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+/**
+ * Writes JSON data to the provided file
+ * @param filePath Path to the file to write
+ * @param data Data to write into the file
+ */
 export function writeJsonFile<T>(filePath: string, data: T){
     fs.writeFileSync(path.resolve(filePath), JSON.stringify(data, null, 4), 'utf8');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "./node_modules/gts/tsconfig-google.json",
     "compilerOptions": {
-        "sourceMap": false,
+        "sourceMap": true,
         "rootDir": "src",
         "outDir": "dist",
         "module": "commonjs",


### PR DESCRIPTION
Paves way to add commands from the server.  A sample set of commands has been added:

`!sr set team [team name]` Sets team name.  Admin only
`!sr team`: Returns team name

`set` commands are available to server admins only.  Server `admins: string[]` is a new property on the server objects in the config file.  Place the username of admins in it.

In other news, the console is now colored, and I've added vsc debugging support